### PR TITLE
replacing two icons on about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -70,7 +70,7 @@
             <div class="row">
                 <div class="col s12 m4">
                     <div class="icon-block">
-                        <h2 class="center brown-text"><i class="material-icons">flash_on</i></h2>
+                        <h2 class="center brown-text"><i class="material-icons">lightbulb_outline</i></h2> <!-- flash_on -->
                         <h5 class="center">Application Concept</h5>
                         <p class="light">We wanted to provide a map based UI for commuters that want to see where the nearest train to their station might be. There doesn't seem to be any page or app that provides anything other than text. The MARTA API returns all trains, all lines, all stations. We filter that data for the user's station of interest and present it on a map so the user can easily see when trains might arrive.</p>
                     </div>
@@ -93,7 +93,7 @@
                 </div>
                 <div class="col s12 m4">
                     <div class="icon-block">
-                        <h2 class="center brown-text"><i class="material-icons">settings</i></h2>
+                        <h2 class="center brown-text"><i class="material-icons">build</i></h2> <!-- settings -->
                         <h5 class="center">Technologies</h5>
                         <p class="light">
                             <ul class="center light">


### PR DESCRIPTION
Simply replaced the flash_on and settings icons with more appropriate choices: lightbulb_outline and build